### PR TITLE
Fix RuntimeError when running example code with CPU

### DIFF
--- a/opennre/pretrain.py
+++ b/opennre/pretrain.py
@@ -74,7 +74,7 @@ def get_model(model_name, root_path=default_root_path):
                                                      word2vec=word2vec,
                                                      dropout=0.5)
         m = model.SoftmaxNN(sentence_encoder, len(rel2id), rel2id)
-        m.load_state_dict(torch.load(ckpt)['state_dict'])
+        m.load_state_dict(torch.load(ckpt, map_location='cpu')['state_dict'])
         return m
     elif model_name == 'wiki80_bert_softmax':
         download_pretrain(model_name)
@@ -84,7 +84,7 @@ def get_model(model_name, root_path=default_root_path):
         sentence_encoder = encoder.BERTEncoder(
             max_length=80, pretrain_path=os.path.join(root_path, 'pretrain/bert-base-uncased'))
         m = model.SoftmaxNN(sentence_encoder, len(rel2id), rel2id)
-        m.load_state_dict(torch.load(ckpt)['state_dict'])
+        m.load_state_dict(torch.load(ckpt, map_location='cpu')['state_dict'])
         return m
     else:
         raise NotImplementedError


### PR DESCRIPTION
Fix the `RuntimeError` when running the example code as following on MacOS.


```
import opennre

model = opennre.get_model('wiki80_cnn_softmax')
print(model.infer({'text': 'He was the son of Máel Dúin mac Máele Fithrich, and grandson of the high king Áed Uaridnach (died 612).', 'h': {'pos': (18, 46)}, 't': {'pos': (78, 91)}}))
```

