### PR TITLE
fix: data parallel bug

### DIFF
--- a/opennre/framework/data_loader.py
+++ b/opennre/framework/data_loader.py
@@ -197,6 +197,7 @@ class BagREDataset(data.Dataset):
             scope.append((start, start + c))
             start += c
         assert(start == seqs[0].size(0))
+        scope = torch.tensor(scope).long()
         label = torch.tensor(label).long() # (B)
         return [label, bag_name, scope] + seqs
 
@@ -211,6 +212,7 @@ class BagREDataset(data.Dataset):
         for c in count:
             scope.append((start, start + c))
             start += c
+        scope = torch.tensor(scope).long()
         label = torch.tensor(label).long() # (B)
         return [label, bag_name, scope] + seqs
 


### PR DESCRIPTION
The origin type of variable `scope` is `list`, it can't be splitted into sub-batches when using multi-gpu, which may raise an error in calculating each bag's query.
One way to reproduce this error is using `bag_re` mode, setting parameter `bag_size==0` and using multi-gpu to train, the error will occur in code line `99-100` of file `OpenNRE/opennre/model/bag_attention.py`.