### PR TITLE
fix: data parallel bug

### DIFF
--- a/opennre/framework/data_loader.py
+++ b/opennre/framework/data_loader.py
@@ -191,12 +191,14 @@ class BagREDataset(data.Dataset):
         seqs = data[3:]
         for i in range(len(seqs)):
             seqs[i] = torch.cat(seqs[i], 0) # (sumn, L)
+            seqs[i] = seqs[i].expand((torch.cuda.device_count(), ) + seqs[i].size())
         scope = [] # (B, 2)
         start = 0
         for c in count:
             scope.append((start, start + c))
             start += c
-        assert(start == seqs[0].size(0))
+        assert(start == seqs[0].size(1))
+        scope = torch.tensor(scope).long()
         label = torch.tensor(label).long() # (B)
         return [label, bag_name, scope] + seqs
 

--- a/opennre/model/bag_attention.py
+++ b/opennre/model/bag_attention.py
@@ -83,6 +83,14 @@ class BagAttention(BagRE):
             pos2 = pos2.view(-1, pos2.size(-1))
             if mask is not None:
                 mask = mask.view(-1, mask.size(-1))
+        else:
+            begin, end = scope[0][0], scope[-1][1]
+            token = token[:, begin:end, :].view(-1, token.size(-1))
+            pos1 = pos1[:, begin:end, :].view(-1, pos1.size(-1))
+            pos2 = pos2[:, begin:end, :].view(-1, pos2.size(-1))
+            if mask is not None:
+                mask = mask[:, begin:end, :].view(-1, mask.size(-1))
+            scope = torch.sub(scope, torch.zeros_like(scope).fill_(begin))
 
         if mask is not None:
             rep = self.sentence_encoder(token, pos1, pos2, mask) # (nsum, H) 


### PR DESCRIPTION
This PR is about some issues of parameter `bag_size`.
I occur the same issue like #208, setting the `bag_size` can easily solve this issue but it may limit the size of bag actually.
If we have 2 gpus, the corresponding `collate_fn` function of `bag_size==0` will simply divide the token tensor whose shape is `sumn, L` into two parts. However, the right thing is trying to divide bags rather than sentences into several parts.
I notice that if the value of `bag_size` is not equal zero, the corresponding processing function has been replaced by `collate_bag_size_fn` which will ensure that all sentences of each bag are assigned to the same GPU.
I try to provide one possible way to support the mode of variable lengths of bags in my code. I only add the code for processing the situation when `bag_size==0`, in fact, this part can also processing the case if `bag_size` is not equal zero.
Thanks~