### PR TITLE
fix: a reduction in testing time

### DIFF
--- a/opennre/framework/bag_re.py
+++ b/opennre/framework/bag_re.py
@@ -168,13 +168,14 @@ class BagRE(nn.Module):
                 scope = data[2]
                 args = data[3:]
                 logits = self.model(None, scope, *args, train=False, bag_size=self.bag_size) # results after softmax
-                for i in range(logits.size(0)):
+                logits = logits.cpu().numpy()
+                for i in range(len(logits)):
                     for relid in range(self.model.module.num_class):
                         if self.model.module.id2rel[relid] != 'NA':
                             pred_result.append({
                                 'entpair': bag_name[i][:2], 
                                 'relation': self.model.module.id2rel[relid], 
-                                'score': logits[i][relid].item()
+                                'score': logits[i][relid]
                             })
             result = eval_loader.dataset.eval(pred_result)
         return result


### PR DESCRIPTION
The original method itemizes each tensor in turn, which takes more time.

Before fixing: 2min50s
After fixing: 1min5s

The test device is NVIDIA 2080ti GPU.