### PR TITLE
fix: a backpropagation bug in relation embedding

### DIFF
--- a/opennre/model/bag_attention.py
+++ b/opennre/model/bag_attention.py
@@ -127,8 +127,7 @@ class BagAttention(BagRE):
         else:
             if bag_size == 0:
                 bag_logits = []
-                att_score = torch.matmul(rep, 
-                                         t.data.transpose(0, 1)) # (nsum, H) * (H, N) -> (nsum, N)
+                att_score = torch.matmul(rep, self.fc.weight.transpose(0, 1)) # (nsum, H) * (H, N) -> (nsum, N)
                 for i in range(len(scope)):
                     bag_mat = rep[scope[i][0]:scope[i][1]] # (n, H)
                     softmax_att_score = self.softmax(att_score[scope[i][0]:scope[i][1]].transpose(0, 1)) # (N, (softmax)n) 


### PR DESCRIPTION
Use `self.fc.weight` instead of `self.fc.weight.data`. The auc of PCNN+ATT will increase about 0.01 (0.32-->0.33).